### PR TITLE
DownloadInfo, new releases endpoints

### DIFF
--- a/ymdantic/adapters/pydantic_factory.py
+++ b/ymdantic/adapters/pydantic_factory.py
@@ -7,7 +7,7 @@ from ymdantic.models.base import YMBaseModel
 class PydanticFactory:
     @staticmethod
     def load(data: Dict[str, Any], type_: Any) -> Any:
-        client = data.get("__client")
+        client = data.pop("__client")
         model: YMBaseModel = TypeAdapter(type_).validate_python(
             data,
             context={"client": client},

--- a/ymdantic/client/yandex_music.py
+++ b/ymdantic/client/yandex_music.py
@@ -15,6 +15,9 @@ from ymdantic.models import (
     Playlist,
     TrackType,
     DownloadInfo,
+    NewReleasesResponse,
+    NewReleases,
+    NewReleasesBlock,
 )
 
 
@@ -30,7 +33,7 @@ class YMClient(AiohttpClient):
             base_url=base_url,
             headers={
                 "Authorization": f"OAuth {token}",
-                "X-Yandex-Music-Client": "YandexMusic/648",
+                "X-Yandex-Music-Client": "YandexMusic/649",
             },
         )
 
@@ -89,6 +92,14 @@ class YMClient(AiohttpClient):
     ) -> Response[ChartBlock]:
         ...
 
+    async def get_new_releases_old(self) -> NewReleasesBlock:
+        response = await self.get_new_releases_old_request()
+        return response.result
+
+    @get("landing3/new-releases")
+    async def get_new_releases_old_request(self) -> Response[NewReleasesBlock]:
+        ...
+
     async def get_playlist(
         self,
         playlist_id: Union[int, str],
@@ -145,4 +156,20 @@ class YMClient(AiohttpClient):
         self,
         album_ids: List[Union[int, str]],
     ) -> Response[List[ShortAlbum]]:
+        ...
+
+    async def get_editorial_new_releases(self) -> List[NewReleases]:
+        response = await self.get_editorial_new_releases_request()
+        return response.new_releases
+
+    @get("landing/block/editorial/new-releases/ALL_albums_of_the_month")
+    async def get_editorial_new_releases_request(self) -> NewReleasesResponse:
+        ...
+
+    async def get_recommended_new_releases(self) -> List[NewReleases]:
+        response = await self.get_recommended_new_releases_request()
+        return response.new_releases
+
+    @get("landing/block/new-releases")
+    async def get_recommended_new_releases_request(self) -> NewReleasesResponse:
         ...

--- a/ymdantic/client/yandex_music.py
+++ b/ymdantic/client/yandex_music.py
@@ -78,12 +78,15 @@ class YMClient(AiohttpClient):
     ) -> Response[List[DownloadInfo]]:
         ...
 
-    async def get_chart(self) -> ChartBlock:
-        response = await self.get_chart_request()
+    async def get_chart(self, limit: Optional[int] = None) -> ChartBlock:
+        response = await self.get_chart_request(limit=limit)
         return response.result
 
     @get("landing3/chart")
-    async def get_chart_request(self) -> Response[ChartBlock]:
+    async def get_chart_request(
+        self,
+        limit: Optional[int] = None,
+    ) -> Response[ChartBlock]:
         ...
 
     async def get_playlist(

--- a/ymdantic/mixins.py
+++ b/ymdantic/mixins.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 class ClientMixin:
     """Миксин, добавляющий в Pydantic модель клиент для отправки запросов."""
 
-    __client: "YMClient"
+    _client: "YMClient"
 
     @model_validator(mode="before")
     def inject_ym_client(
@@ -25,7 +25,7 @@ class ClientMixin:
         :return: Словарь с данными модели.
         """
         if info.context is not None:
-            cls.__client = info.context.get("client")
+            cls._client = info.context.get("client")
         return obj
 
 

--- a/ymdantic/models/__init__.py
+++ b/ymdantic/models/__init__.py
@@ -6,12 +6,14 @@ from .albums import Album, ShortAlbum
 from .tracks import (
     TrackType,
     DownloadInfo,
+    DownloadInfoDirect,
     Track,
     UnavailableTrack,
     Podcast,
     UnavailablePodcast,
 )
 from .artists import Artist
+from .s3 import S3FileUrl
 
 # Ребилд моделей с учётом новых изменений. (TrackType)
 ShortAlbum.model_rebuild()
@@ -24,6 +26,7 @@ __all__ = (
     "Artist",
     "TrackType",
     "DownloadInfo",
+    "DownloadInfoDirect",
     "ChartBlock",
     "NewReleasesBlock",
     "Playlist",
@@ -33,4 +36,5 @@ __all__ = (
     "UnavailablePodcast",
     "NewReleasesResponse",
     "NewReleases",
+    "S3FileUrl",
 )

--- a/ymdantic/models/__init__.py
+++ b/ymdantic/models/__init__.py
@@ -1,4 +1,5 @@
-from .landing3 import ChartBlock
+from .landing3 import ChartBlock, NewReleasesBlock
+from .landing import NewReleasesResponse, NewReleases
 from .playlists import Playlist
 from .response import Response
 from .albums import Album, ShortAlbum
@@ -24,9 +25,12 @@ __all__ = (
     "TrackType",
     "DownloadInfo",
     "ChartBlock",
+    "NewReleasesBlock",
     "Playlist",
     "Track",
     "UnavailableTrack",
     "Podcast",
     "UnavailablePodcast",
+    "NewReleasesResponse",
+    "NewReleases",
 )

--- a/ymdantic/models/landing/__init__.py
+++ b/ymdantic/models/landing/__init__.py
@@ -1,0 +1,3 @@
+from .editorial import NewReleasesResponse, NewReleases
+
+__all__ = ("NewReleasesResponse", "NewReleases")

--- a/ymdantic/models/landing/editorial/__init__.py
+++ b/ymdantic/models/landing/editorial/__init__.py
@@ -1,0 +1,3 @@
+from .new_releases import NewReleasesResponse, NewReleases
+
+__all__ = ("NewReleasesResponse", "NewReleases")

--- a/ymdantic/models/landing/editorial/new_releases.py
+++ b/ymdantic/models/landing/editorial/new_releases.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from typing import List
+
+from ymdantic.models.base import YMBaseModel
+from ymdantic.models.landing.landing_album import LandingAlbum
+from ymdantic.models.landing.landing_artist import LandingArtist
+from ymdantic.models.landing.landing_cover import LandingPlaylistCover
+
+
+class NewReleases(YMBaseModel):
+    """Pydantic модель, представляющая информацию о новых релизах."""
+
+    cover: LandingPlaylistCover
+    # Обложка плейлиста. Содержит информацию о цветах обложки и URI обложки.
+    artists: List[LandingArtist]
+    # Список артистов, участвующих в новых релизах.
+    album: LandingAlbum
+    # Информация об альбоме в новых релизах.
+    release_date: datetime
+    # Дата релиза нового альбома.
+
+
+class NewReleasesResponse(YMBaseModel):
+    """Pydantic модель, представляющая ответ на запрос о новых релизах."""
+
+    new_releases: List[NewReleases]
+    # Список новых релизов.

--- a/ymdantic/models/landing/landing_album.py
+++ b/ymdantic/models/landing/landing_album.py
@@ -1,0 +1,19 @@
+from typing import Literal, Optional
+
+from ymdantic.models.base import YMBaseModel
+from ymdantic.models.landing.landing_cover import LandingCover
+
+
+class LandingAlbum(YMBaseModel):
+    """Pydantic модель, представляющая информацию о LandingAlbum."""
+
+    id: int
+    # Уникальный идентификатор альбома.
+    title: str
+    # Название альбома.
+    cover: LandingCover
+    # Обложка альбома. Содержит информацию о цветах для обложки и URI обложки.
+    album_type: Optional[Literal["single"]] = None
+    # Тип альбома.
+    content_warning: Optional[Literal["explicit"]] = None
+    # Предупреждение о содержании.

--- a/ymdantic/models/landing/landing_artist.py
+++ b/ymdantic/models/landing/landing_artist.py
@@ -1,0 +1,13 @@
+from ymdantic.models.base import YMBaseModel
+from ymdantic.models.landing.landing_cover import LandingCover
+
+
+class LandingArtist(YMBaseModel):
+    """Pydantic модель, представляющая информацию о LandingArtist."""
+
+    id: int
+    # Уникальный идентификатор артиста.
+    name: str
+    # Имя артиста.
+    cover: LandingCover
+    # Обложка артиста. Содержит информацию о цветах обложки и URI обложки.

--- a/ymdantic/models/landing/landing_cover.py
+++ b/ymdantic/models/landing/landing_cover.py
@@ -1,0 +1,48 @@
+from typing import Optional
+
+from pydantic import HttpUrl
+
+from ymdantic.models.base import YMBaseModel
+from ymdantic.models.tracks import DerivedColors
+
+
+class LandingPlaylistCover(YMBaseModel):
+    """Pydantic модель, представляющая информацию об обложке плейлиста на лендинге."""
+
+    uri: str  # TODO: get_url
+    # URI обложки плейлиста.
+    color: Optional[str] = None
+    # Основной цвет обложки плейлиста.
+    derived_colors: Optional[DerivedColors] = None
+    # Дополнительные цвета обложки плейлиста.
+
+    def get_image_url(self, size: str = "200x200") -> Optional[HttpUrl]:
+        """
+        Возвращает ссылку на изображение обложки.
+
+        :param size: Размер изображения.
+        :return: Ссылка на изображение обложки.
+        """
+        if self.uri is None:
+            return None
+        return HttpUrl(f"https://{self.uri.replace('%%', size)}")
+
+
+class LandingCover(YMBaseModel):
+    """Pydantic модель, представляющая информацию об обложке на лендинге."""
+
+    uri: str  # TODO: get_url
+    # URI обложки.
+    color: str
+    # Основной цвет обложки.
+    derived_colors: DerivedColors
+    # Дополнительные цвета обложки.
+
+    def get_image_url(self, size: str = "200x200") -> HttpUrl:
+        """
+        Возвращает ссылку на изображение обложки.
+
+        :param size: Размер изображения.
+        :return: Ссылка на изображение обложки.
+        """
+        return HttpUrl(f"https://{self.uri.replace('%%', size)}")

--- a/ymdantic/models/landing3/__init__.py
+++ b/ymdantic/models/landing3/__init__.py
@@ -1,3 +1,3 @@
-from .block import ChartBlock
+from .block import ChartBlock, NewReleasesBlock
 
-__all__ = ("ChartBlock",)
+__all__ = ("ChartBlock", "NewReleasesBlock")

--- a/ymdantic/models/landing3/block.py
+++ b/ymdantic/models/landing3/block.py
@@ -1,10 +1,10 @@
-from typing import Literal, TypeVar
+from typing import Literal, TypeVar, List
 
 from ymdantic.models.base import YMBaseModel
 from ymdantic.models.landing3.chart import Chart
 from ymdantic.models.landing3.menu import Menu
 
-BlockType = Literal["chart"]
+BlockType = Literal["chart", "new-releases"]
 BlockVar = TypeVar("BlockVar")
 
 
@@ -28,7 +28,20 @@ class ChartBlock(BaseBlock):
     # Меню блока
     type: Literal["chart"]
     # Тип блока, в данном случае "chart".
+    type_for_from: Literal["chart"]
+    # Тип для источника блока. В данном случае "chart".
     chart_description: str
     # Описание списка чартов.
     chart: Chart
     # Объект чарта, содержащий информацию о нём (является плейлистом).
+
+
+class NewReleasesBlock(BaseBlock):
+    """Pydantic модель, представляющая информацию о блоке с новыми релизами."""
+
+    type: Literal["new-releases"]
+    # Тип блока, в данном случае "new-releases".
+    type_for_from: Literal["new-releases"]
+    # Тип для источника блока. В данном случае "new-releases".
+    new_releases: List[int]
+    # Список ID новых релизов (альбомов).

--- a/ymdantic/models/s3.py
+++ b/ymdantic/models/s3.py
@@ -1,0 +1,44 @@
+from hashlib import md5
+
+from pydantic import BaseModel, HttpUrl
+
+PRIVATE_KEY = "uz0zSpaYCLmgk6C7YLdo5F"
+
+
+class S3FileUrl(BaseModel):
+    """Pydantic модель, представляющая данные о URL файла на S3."""
+
+    s: str
+    # Используется для формирования подписи.
+    ts: str
+    # Временная метка для URL файла S3.
+    path: str
+    # Путь к файлу на S3.
+    host: str
+    # Хост S3.
+
+    @property
+    def sign(self) -> str:
+        """
+        Генерирует подпись для URL файла S3.
+
+        Этот метод конкатенирует приватный ключ, путь (исключая первый слеш), и атрибут
+        's' экземпляра. Полученная строка затем преобразуется в байты и хешируется с
+        использованием алгоритма MD5. Возвращается шестнадцатеричное представление этого
+        хеша в качестве подписи.
+
+        :return: Хеш MD5 конкатенированной строки в виде шестнадцатеричной строки.
+        """
+        return md5((PRIVATE_KEY + self.path[1::] + self.s).encode("utf-8")).hexdigest()
+
+    @property
+    def url(self) -> HttpUrl:
+        """
+        Генерирует URL на S3 для файла.
+
+        Этот метод формирует URL, используя хост, подпись, временную метку и путь файла.
+        URL возвращается в формате HttpUrl.
+
+        :return: Сформированный URL для файла S3.
+        """
+        return HttpUrl(f"https://{self.host}/get-mp3/{self.sign}/{self.ts}{self.path}")

--- a/ymdantic/models/tracks/__init__.py
+++ b/ymdantic/models/tracks/__init__.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from .derived_colors import DerivedColors
-from .download_info import DownloadInfo
+from .download_info import DownloadInfo, DownloadInfoDirect
 from .fade import Fade
 from .lyrics_info import LyricsInfo
 from .major import Major
@@ -19,6 +19,7 @@ __all__ = (
     "Podcast",
     "UnavailablePodcast",
     "DownloadInfo",
+    "DownloadInfoDirect",
     "TrackAlbum",
     "DerivedColors",
     "R128",

--- a/ymdantic/models/tracks/download_info.py
+++ b/ymdantic/models/tracks/download_info.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from pydantic import HttpUrl
 
+from ymdantic.models.s3 import S3FileUrl
 from ymdantic.models.base import YMBaseModel
 
 CodecType = Literal["mp3", "aac"]
@@ -22,3 +23,19 @@ class DownloadInfo(YMBaseModel):
     # Является ли ссылка на S3-хранилище прямой ссылкой на скачивание трека.
     bitrate_in_kbps: int
     # Битрейт трека в кбит/с.
+
+
+class DownloadInfoDirect(DownloadInfo):
+    direct_url_info: S3FileUrl
+
+    @property
+    def direct_url(self) -> HttpUrl:
+        """
+        Генерирует прямой URL для скачивания трека.
+
+        Этот метод возвращает URL, сформированный на основе информации о прямом URL,
+        хранящейся в атрибуте 'direct_url_info' экземпляра.
+
+        :return: Прямой URL для скачивания трека.
+        """
+        return self.direct_url_info.url

--- a/ymdantic/models/tracks/track.py
+++ b/ymdantic/models/tracks/track.py
@@ -12,7 +12,7 @@ from ymdantic.models.tracks.derived_colors import DerivedColors
 from ymdantic.models.tracks.track_album import TrackAlbum
 from ymdantic.models.tracks.lyrics_info import LyricsInfo
 from ymdantic.models.tracks.major import Major
-
+from ymdantic.models.tracks.download_info import DownloadInfo, DownloadInfoDirect
 
 AvailableForOptions = List[Literal["bookmate"]]
 TrackSource = Literal["OWN", "OWN_REPLACED_TO_UGC"]
@@ -81,6 +81,7 @@ class BaseTrack(YMBaseModel, DeprecatedMixin):
     # Идентификатор плеера трека (если есть). Плеер требуется для
     # отображения фонового видео.
     best: Optional[bool] = None
+
     # Является ли трек лучшим (поле доступно при получении альбома с треками
     # `get_album_with_tracks`).
 
@@ -156,6 +157,7 @@ class Track(BaseTrack):
     available_for_options: AvailableForOptions
     # Доступные опции для трека.
     chart: Optional[ChartPosition] = None
+
     # Информация о чарте, если трек входит в чарт.
 
     def get_cover_url(self, size: str = "200x200") -> HttpUrl:
@@ -167,3 +169,19 @@ class Track(BaseTrack):
         :return: URL изображения обложки.
         """
         return HttpUrl(f"https://{self.cover_uri.replace('%%', size)}")
+
+    async def get_download_info(self) -> List[DownloadInfo]:
+        """
+        Получает информацию для скачивания трека.
+
+        :return: Информация для скачивания трека.
+        """
+        return await self._client.get_track_download_info(track_id=self.id)
+
+    async def get_download_info_direct(self) -> List[DownloadInfoDirect]:
+        """
+        Получает информацию для скачивания трека + прямую ссылку.
+
+        :return: Информация для скачивания трека + прямая ссылка.
+        """
+        return await self._client.get_track_download_info_direct(track_id=self.id)


### PR DESCRIPTION
Новый функционал:
- Возможность установить лимит для `get_chart` эндпоинта
- 3 эндпоинта для новых релизов (recommended, editorial, old)
- Возможность получить информацию о скачивании трека с прямой ссылкой (get_track_download_info_direct)
